### PR TITLE
fix: alert from thread performance checker.

### DIFF
--- a/Sources/FCL-SDK/FCL.swift
+++ b/Sources/FCL-SDK/FCL.swift
@@ -25,7 +25,12 @@ public class FCL: NSObject {
     public var delegate: FCLDelegate?
 
     var flowAPIClient: Client {
-        Client(network: config.network)
+        get async throws {
+            let task = Task(priority: .utility) {
+                Client(network: config.network)
+            }
+            return await task.value
+        }
     }
 
     private var webAuthSession: ASWebAuthenticationSession?
@@ -427,11 +432,8 @@ extension FCL {
     }
 
     func sendIX(ix: Interaction) async throws -> Identifier {
-        let result = Task(priority: .background) {
-            let tx = try await ix.toFlowTransaction()
-            return try await fcl.flowAPIClient.sendTransaction(transaction: tx)
-        }
-        return try await result.value
+        let tx = try await ix.toFlowTransaction()
+        return try await fcl.flowAPIClient.sendTransaction(transaction: tx)
     }
 
 }


### PR DESCRIPTION
```
Thread Performance Checker: Thread running at QOS_CLASS_USER_INITIATED waiting on a lower QoS thread running at QOS_CLASS_DEFAULT. Investigate ways to avoid priority inversions
PID: 76473, TID: 29367788
Backtrace
=================================================================
3   NIOPosix                            0x000000010710926c $s8NIOPosix27MultiThreadedEventLoopGroupC014setupThreadAnddE033_C2B1528F4FBA68A3DBFA89DBAEBE9D4DLL4name06parentF015selectorFactory11initializerAA010SelectabledE0CSS_AcA8SelectorCyAA15NIORegistrationVGyKcyAA9NIOThreadCctFZ + 468
4   NIOPosix                            0x0000000107109e04 $s8NIOPosix27MultiThreadedEventLoopGroupC18threadInitializers15selectorFactoryACSayyAA9NIOThreadCcG_AA8SelectorCyAA15NIORegistrationVGyKctcfcAA010SelectabledE0CyAGcXEfU_ + 556
5   NIOPosix                            0x0000000107109ea8 $s8NIOPosix27MultiThreadedEventLoopGroupC18threadInitializers15selectorFactoryACSayyAA9NIOThreadCcG_AA8SelectorCyAA15NIORegistrationVGyKctcfcAA010SelectabledE0CyAGcXEfU_TA + 40
6   libswiftCore.dylib                  0x000000018bcc6978 $sSlsE3mapySayqd__Gqd__7ElementQzKXEKlF + 428
7   NIOPosix                            0x0000000107109b4c $s8NIOPosix27MultiThreadedEventLoopGroupC18threadInitializers15selectorFactoryACSayyAA9NIOThreadCcG_AA8SelectorCyAA15NIORegistrationVGyKctcfc + 444
8   NIOPosix                            0x0000000107109980 $s8NIOPosix27MultiThreadedEventLoopGroupC18threadInitializers15selectorFactoryACSayyAA9NIOThreadCcG_AA8SelectorCyAA15NIORegistrationVGyKctcfC + 72
9   NIOPosix                            0x0000000107109860 $s8NIOPosix27MultiThreadedEventLoopGroupC15numberOfThreads15selectorFactoryACSi_AA8SelectorCyAA15NIORegistrationVGyKctcfC + 312
10  NIOPosix                            0x000000010710968c $s8NIOPosix27MultiThreadedEventLoopGroupC15numberOfThreadsACSi_tcfC + 40
11  FlowSDK                             0x00000001062effa0 $s7FlowSDK6ClientC4host4portACSS_SitcfC + 92
12  FlowSDK                             0x00000001062f0390 $s7FlowSDK6ClientC7networkAcA7NetworkO_tcfC + 96
13  FCL_SDK                             0x0000000105cfac8c $s7FCL_SDK0A0C13flowAPIClient04FlowB06ClientCvg + 104
14  FCL_SDK                             0x0000000105d41368 $s7FCL_SDK16RefBlockResolverC7resolve2ixAA11InteractionVAG_tYaKFTY0_ + 144
15  libswift_Concurrency.dylib          0x00000001af0754f8 _ZN5swift34runJobInEstablishedExecutorContextEPNS_3JobE + 336
16  libswift_Concurrency.dylib          0x00000001af076170 _ZL17swift_job_runImplPN5swift3JobENS_11ExecutorRefE + 80
17  libdispatch.dylib                   0x0000000107930fb4 _dispatch_continuation_pop + 152
18  libdispatch.dylib                   0x0000000107930190 _dispatch_async_redirect_invoke + 904
19  libdispatch.dylib                   0x00000001079428ac _dispatch_root_queue_drain + 440
20  libdispatch.dylib                   0x000000010794353c _dispatch_worker_thread2 + 248
21  libsystem_pthread.dylib             0x00000001af2568c0 _pthread_wqthread + 224
22  libsystem_pthread.dylib             0x00000001af2556c0 start_wqthread + 8
```