### PR TITLE
fix: update Twitter URL to x.com and correct typo

### DIFF
--- a/FCL-SDK.podspec
+++ b/FCL-SDK.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Dawson' => 'dawson@portto.com', 'Scott' => 'scott@portto.com' }
   s.source           = { :git => 'https://github.com/portto/fcl-swift.git', :tag => s.version.to_s }
-  s.social_media_url = 'https://twitter.com/BloctoApp'
+  s.social_media_url = 'https://x.com/BloctoApp'
 
   s.swift_version = '5.0.0'
   s.ios.deployment_target = '13.0'

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Task {
 - Declare a wallet provider type and conform the protocol [WalletProvider](./Sources/FCL-SDK/WalletProvider/WalletProvider.swift).
 - If building a wallet involve back channel communication, read the [wallet guide](https://github.com/onflow/fcl-js/blob/master/packages/fcl/src/wallet-provider-spec/draft-v3.md) first to build the concept of the implementation and use method from `WalletProvider` to fulfill your business logic.
 
-Every walllet provider can use below property from `WalletProvider` to customize icon, title and description. Those info will be shown [here](#wallet-selection).
+Every wallet provider can use below property from `WalletProvider` to customize icon, title and description. Those info will be shown [here](#wallet-selection).
 ```
 var providerInfo: ProviderInfo { get }
 ```


### PR DESCRIPTION

- Replaced outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.
- Fixed typo: "walllet" → "wallet".
